### PR TITLE
fix(frontend): rename duplicate For Patients section and add missing closing div in Footer

### DIFF
--- a/frontend/src/components/Footer.jsx
+++ b/frontend/src/components/Footer.jsx
@@ -53,16 +53,19 @@ const Footer = () => {
             </div>
           </div>
 
+          {/* Patient Portal */}
           <div>
-            <h4 className="text-lg font-semibold text-white mb-4">For Patients</h4>
+            <h4 className="text-lg font-semibold text-white mb-4">Patient Portal</h4>
             <div className="space-y-3">
               <Link to="/dashboard" className="block text-sm text-gray-300 hover:text-white">Dashboard</Link>
               <Link to="/search" className="block text-sm text-gray-300 hover:text-white">Search Doctors</Link>
               <Link to="/book-ambulance" className="block text-sm text-gray-300 hover:text-white">Ambulance</Link>
+            </div>
+          </div>
 
-          {/* For Patients */}
+          {/* Manage Account */}
           <div>
-            <h4 className="text-lg font-semibold text-white mb-4">For Patients</h4>
+            <h4 className="text-lg font-semibold text-white mb-4">Manage Account</h4>
             <div className="space-y-3">
               <Link to="/login" className="block text-sm text-gray-300 hover:text-white">Login</Link>
               <Link to="/register" className="block text-sm text-gray-300 hover:text-white">Register</Link>


### PR DESCRIPTION
**Description**
This PR fixes the Footer component by:
- Removing the duplicated "For Patients" section.
- Renaming the first duplicated section to "Patient Portal" and the second to "Manage Account" for better clarity and organization.
- Adding missing closing `div` tags to correct the JSX structure and prevent rendering issues.

**Testing**
- Verified the footer renders correctly without errors.
- Checked that all links navigate to their respective pages as intended.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated footer section headings for improved clarity and semantic accuracy.
  * Split "For Patients" into "Patient Portal" and "Manage Account" sections with reorganized links.
  * Adjusted section comments and structure for better organization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->