### PR TITLE
Add ambulance driver role and fields to user registration (Issue #88)

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -369,17 +369,17 @@ exports.register = catchAsync(async (req, res, next) => {
   }
 
   // Validate role if provided
-  const validRoles = ["patient", "doctor", "nurse", "admin"];
+  const validRoles = ["patient", "doctor", "nurse", "admin", "technician", "ambulance"];
   if (role && !validRoles.includes(role)) {
     return next(new ValidationError("Invalid role specified"));
   }
 
   // Create user object with basic fields
   const userData = {
-    name: name.trim(),
-    email: email.toLowerCase(),
-    password, // Will be hashed by the User model pre-save hook
-    role: role || "patient",
+  name: name.trim(),
+  email: email.toLowerCase(),
+  password, // Will be hashed by the User model pre-save hook
+  role: role || "patient",
   };
 
   // Add professional fields if role is doctor or nurse
@@ -404,6 +404,16 @@ exports.register = catchAsync(async (req, res, next) => {
     } catch (error) {
       return next(error);
     }
+  }
+
+  // Add ambulance driver fields if role is ambulance
+  if (role === "ambulance") {
+    const { driverLicenseNumber, vehicleRegistrationNumber } = req.body;
+    if (!driverLicenseNumber || !vehicleRegistrationNumber) {
+      return next(new ValidationError("Driver's License No. and Vehicle Registration No. are required for ambulance drivers"));
+    }
+    userData.driverLicenseNumber = driverLicenseNumber.trim();
+    userData.vehicleRegistrationNumber = vehicleRegistrationNumber.trim();
   }
 
   // Create new user

--- a/backend/models/User.js
+++ b/backend/models/User.js
@@ -28,7 +28,7 @@ const UserSchema = new mongoose.Schema({
   },
   role: {
     type: String,
-    enum: ['patient', 'doctor', 'nurse', 'admin', 'technician', 'ambulance'],
+  enum: ['patient', 'doctor', 'nurse', 'admin', 'technician', 'ambulance'],
     default: 'patient',
   },
   
@@ -79,6 +79,20 @@ const UserSchema = new mongoose.Schema({
     required: function () {
       return this.role === 'technician';
     },
+
+  // --- Ambulance Driver Specific Fields ---
+  driverLicenseNumber: {
+    type: String,
+    required: function () {
+      return this.role === 'ambulance';
+    },
+  },
+  vehicleRegistrationNumber: {
+    type: String,
+    required: function () {
+      return this.role === 'ambulance';
+    },
+  },
   },
 
   // --- Patient-Specific Medical Info ---

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -24,7 +24,8 @@
         "react-icons": "^5.5.0",
         "react-router-dom": "^7.6.3",
         "react-toastify": "^11.0.5",
-        "socket.io-client": "^4.8.1"
+        "socket.io-client": "^4.8.1",
+        "vite-plugin-static-copy": "^3.1.1"
       },
       "devDependencies": {
         "@eslint/js": "^9.29.0",

--- a/frontend/src/pages/RegisterPage.jsx
+++ b/frontend/src/pages/RegisterPage.jsx
@@ -164,7 +164,8 @@ const RegisterPage = () => {
             <option value="patient">Patient</option>
             <option value="doctor">Doctor</option>
             <option value="nurse">Nurse</option>
-            <option value="technician">Lab Technician</option> {/* Added */}
+            <option value="technician">Lab Technician</option>
+            <option value="ambulance">Ambulance Driver</option>
           </select>
         </div>
 
@@ -359,6 +360,36 @@ const RegisterPage = () => {
               className="w-full p-3 bg-gray-200 dark:bg-primary-dark rounded border-gray-700 text-black dark:text-white"
             />
           </div>
+        )}
+        {role === "ambulance" && (
+          <>
+            <div className="mb-4">
+              <label className="block text-slate-700 dark:text-secondary-text mb-2">
+                Driver's License No.
+              </label>
+              <input
+                type="text"
+                name="driverLicenseNumber"
+                value={formData.driverLicenseNumber || ""}
+                onChange={onChange}
+                required
+                className="w-full p-3 bg-gray-200 dark:bg-primary-dark rounded border-gray-700 text-black dark:text-white"
+              />
+            </div>
+            <div className="mb-4">
+              <label className="block text-slate-700 dark:text-secondary-text mb-2">
+                Vehicle Registration No.
+              </label>
+              <input
+                type="text"
+                name="vehicleRegistrationNumber"
+                value={formData.vehicleRegistrationNumber || ""}
+                onChange={onChange}
+                required
+                className="w-full p-3 bg-gray-200 dark:bg-primary-dark rounded border-gray-700 text-black dark:text-white"
+              />
+            </div>
+          </>
         )}
         <button
           type="submit"


### PR DESCRIPTION
#🚑 Ambulance Driver Role Integration  (ISSUE #88)
##Summary
This PR adds support for "Ambulance Driver" as a distinct professional role on the DocAtHome platform. The following changes were made:

##Backend
Added 'ambulance' to the enum in the model.
Introduced two new fields for ambulance drivers: [driverLicenseNumber] and [vehicleRegistrationNumber]
These fields are required only when the user role is set to 'ambulance'.
Updated registration controller to validate and save these fields during user registration.

##Frontend
Added "Ambulance Driver" as an option in the registration dropdown.
When selected, two new input fields appear for "Driver's License No." and "Vehicle Registration No.".

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Ambulance Driver” as a selectable role during registration.
  * New role-specific fields appear when selected: Driver’s License No. and Vehicle Registration No.
  * These ambulance-specific fields are required to complete registration and are validated server-side.
  * User profiles now support storing ambulance driver details alongside existing professional information (e.g., doctor, nurse, technician).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->