### PR TITLE
fix issue Page Does Not Scroll to Top on Navigation

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -15,7 +15,7 @@ function App() {
         <AnnouncementBanner />
 
         <main className="flex-grow">
-          <AnimatedRoutes />
+            <AnimatedRoutes />
         </main>
 
         {/* scroll-to-to (absolute) */}

--- a/frontend/src/components/AnimatedRoutes.jsx
+++ b/frontend/src/components/AnimatedRoutes.jsx
@@ -55,12 +55,16 @@ import TwoFactorAuthPage from "../pages/TwoFactorAuthPage.jsx";
 
 // 404 Not Found Page
 import NotFoundPage from "../pages/NotFoundPage.jsx";
+import ScrollToUp from "./ScrollToUp.jsx";
+
 
 const AnimatedRoutes = () => {
   const location = useLocation();
 
   return (
     <AnimatePresence mode="wait" initial={false}>
+      {/* scroll to top on every navigation */}
+     <ScrollToUp/>
       <Routes location={location} key={location.pathname}>
         {/* --- Public Routes --- */}
         <Route
@@ -459,6 +463,7 @@ const AnimatedRoutes = () => {
           }
         />
       </Routes>
+
     </AnimatePresence>
   );
 };

--- a/frontend/src/components/ScrollToUp.jsx
+++ b/frontend/src/components/ScrollToUp.jsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollToUp =()=>{
+   const {pathname} =useLocation()
+
+   useEffect(()=>{
+    window.scrollTo({ top: 0, behavior: "smooth" });
+   },[pathname])
+ 
+    return ;
+}
+
+export default ScrollToUp;


### PR DESCRIPTION
Issue :[Page Does Not Scroll to Top on Navigation](https://github.com/shandilya-rajnandini/DocAtHome/issues/190).

Problem Description:  Currently, when navigating between pages, the page does not automatically scroll back to the top. This creates a poor user experience, as users land in the middle or bottom of the new page depending on their previous scroll position.

Solved: I added a ScrollToUp.jsx file that uses useLocation to detect route changes. Now, whenever the route changes, the window automatically scrolls back to the top.